### PR TITLE
ENH: Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This project uses [*towncrier*](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/flowy-code/flowy/tree/main/docs/newsfragments/>.
+
+<!-- towncrier release notes start -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,25 @@ pipx run pre-commit run --all-files
 # Or install the git hook to enforce this
 pipx run pre-commit install
 ```
+
+# Changelog management
+
+We use markdown for the changelog fragments, and they are stored under `docs/newsfragments`
+
+- Use issues to number the snippets
+- Build a final variant with: `towncrier build --version 0.6.3 --date "$(date -u +%Y-%m-%d)"`
+- Supported categories are:
+ + `security`
+ + `removed`
+ + `deprecated`
+ + `added`
+ + `changed`
+ + `fixed`
+
+Here are some sample use cases:
+```sh
+towncrier create -c "Fancy new feature but without an issue attached" +new_feat.added.md
+towncrier create -c "Require C++17 only" 1.changed.md
+```
+
+The generated markdown files can be modified later as well.

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - cpplint
   - libnetcdf
   - hdf5
+  - towncrier

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,37 @@
+[tool.towncrier]
+directory = "docs/newsfragments"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+title_format = "## [{version}](https://github.com/flowy-code/flowy/tree/{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/flowy-code/flowy/issues/{issue})"
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
Should be useful in the long run, ideally I prefer to have issues for every new feature and then number them that way, but at the very least `+new_feat.added.md` or something would be nice.

Some more details about Towncrier [are here](https://towncrier.readthedocs.io/en/stable/markdown.html).