### PR TITLE
ENH: Better lib defaults and netcdf handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
       shell: micromamba-shell {0}
       run: |
         meson test -C build --verbose
+
+    - name: Compile and test without netcdf
+      shell: micromamba-shell {0}
+      run: |
+        meson setup build_nonetcdf --buildtype release --vsenv -Dwith_netcdf=false
+        meson compile -C build_nonetcdf
+        meson test -C build_nonetcdf --verbose

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -37,3 +37,11 @@ jobs:
       run: |
         micromamba activate flowyenv
         meson test -C build --verbose
+
+    - name: Compile and test without netcdf
+      shell: pwsh
+      run: |
+        micromamba activate flowyenv
+        meson setup build_nonetcdf --buildtype release --vsenv -Dwith_netcdf=false
+        meson compile -C build_nonetcdf
+        meson test -C build_nonetcdf --verbose

--- a/flowy/include/definitions.hpp
+++ b/flowy/include/definitions.hpp
@@ -20,4 +20,11 @@ using Vector3 = xt::xtensor_fixed<double, xt::xshape<3>>;
 using MatrixX = xt::xtensor<double, 2>;
 using VectorX = xt::xtensor<double, 1>;
 
+enum StorageDataType
+{
+    Short,
+    Float,
+    Double
+};
+
 } // namespace Flowy

--- a/flowy/include/netcdf_file.hpp
+++ b/flowy/include/netcdf_file.hpp
@@ -1,6 +1,7 @@
 #pragma once
 // GPL v3 License
 // Copyright 2023--present Flowy developers
+#ifdef WITH_NETCDF
 
 #include "flowy/include/topography_file.hpp"
 #include <optional>
@@ -8,13 +9,6 @@
 
 namespace Flowy
 {
-
-enum StorageDataType
-{
-    Short,
-    Float,
-    Double
-};
 
 class NetCDFFile : public TopographyFile
 {
@@ -47,3 +41,5 @@ public:
 };
 
 } // namespace Flowy
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,14 @@ _deps = [
   netcdf_dep
 ]
 
+symbol_visibility = 'default'
+if get_option('default_library') == 'static'
+  # Ensure that if we link a static library into a shared library,
+  # private symbols don't get re-exported.
+  # Kanged from https://github.com/ERGO-Code/HiGHS/pull/1737/files
+  symbol_visibility = 'inlineshidden'
+endif
+
 # Static libraries for the executable and tests, shared for the bindings
 # Generates (linux) libflowy.so && libflowy.a
 flowylib = both_libraries('flowy',
@@ -53,6 +61,8 @@ flowylib = both_libraries('flowy',
   install:true,
   dependencies : _deps,
   include_directories : incdir,
+  gnu_symbol_visibility: symbol_visibility,
+  pic: true,
   cpp_args : cpp_args,
 )
 # Generating both dependencies here is not a heavy ask

--- a/meson.build
+++ b/meson.build
@@ -10,21 +10,18 @@ cpp_args = []
 
 cppc = meson.get_compiler('cpp')
 
-# clang and gcc specific flags
-if cppc.get_id() == 'gcc' or cppc.get_id() == 'clang'
-  cpp_args += cppc.get_supported_arguments([
-    '-Wno-unused-local-typedefs',
-    '-Wno-array-bounds',
-    '-ffast-math',
-    '-fno-finite-math-only',
-    # These are based on recommendations from
-    # https://youtu.be/_enXuIxuNV4?si=LvtMqPwJ6jYbDY66
-    '-fno-semantic-interposition',
-    '-fno-plt',
-    '-fvisibility=hidden',
-    '-Bsymbolic',
-  ])
-endif
+cpp_args += cppc.get_supported_arguments([
+  '-Wno-unused-local-typedefs',  # Ignore unused local typedefs warnings
+  '-Wno-array-bounds',           # Suppress out-of-bounds array access warnings
+  '-ffast-math',                 # Enable faster, non-IEEE math calculations
+  '-fno-finite-math-only',       # Allow Inf and NaN
+  # These are based on recommendations from
+  # https://youtu.be/_enXuIxuNV4?si=LvtMqPwJ6jYbDY66
+  '-fno-semantic-interposition', # Assume no interposition for module functions
+  '-fno-plt',                    # Avoid PLT for function calls within shared libs
+  '-fvisibility=hidden',         # Set default symbol visibility to hidden
+  '-Bsymbolic',                  # Resolve symbols to local definitions
+])
 
 if cpp_args.length() > 0
   message('Adding compiler flags', cpp_args)

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,6 @@ _sources = [
   'src/simulation.cpp',
   'src/topography.cpp',
   'src/config_parser.cpp',
-  'src/netcdf_file.cpp'
 ]
 
 # Library dependencies
@@ -51,6 +50,8 @@ if get_option('with_netcdf')
     netcdf_dep = dependency('netcdf',  language : 'cpp', method: 'pkg-config')
   endif
   _deps += netcdf_dep
+  cpp_args += ['-DWITH_NETCDF']
+  _sources += ['src/netcdf_file.cpp']
 endif
 
 _deps += [
@@ -106,8 +107,11 @@ if get_option('build_tests')
     ['Test_Lobe', 'test/test_lobe.cpp'],
     ['Test_Trunc_Normal', 'test/test_truncated_normal.cpp'],
     ['Test_Raster', 'test/test_rasterization.cpp'],
-    ['Test_FileIO', 'test/test_file_io.cpp']
   ]
+
+  if get_option('with_netcdf')
+    tests += [['Test_FileIO', 'test/test_file_io.cpp']]
+  endif
 
   Catch2 = dependency('Catch2', method : 'cmake', modules : ['Catch2::Catch2WithMain', 'Catch2::Catch2'])
 

--- a/meson.build
+++ b/meson.build
@@ -38,24 +38,27 @@ _sources = [
 ]
 
 # Library dependencies
+_deps = []
 pdflib_dep = dependency('pdf_cpplib', fallback : ['pdf_cpplib', 'pdflib_dep'])
 
 ## Netcdf
-# On windows the conda-forge netcdf pkg-config file tells us to link against a mysterious debug.lib
-# Therefore, we use cmake as the preferred method, which does not make problems
-netcdf_dep = dependency('netcdf',  language : 'cpp', method: 'cmake', required: false)
-# On the linux CI, however, cmake cant find netcdf. So we still use pkg-config as a fallback.
-if not netcdf_dep.found()
-  netcdf_dep = dependency('netcdf',  language : 'cpp', method: 'pkg-config')
+if get_option('with_netcdf')
+  # On windows the conda-forge netcdf pkg-config file tells us to link against a mysterious debug.lib
+  # Therefore, we use cmake as the preferred method, which does not make problems
+  netcdf_dep = dependency('netcdf',  language : 'cpp', method: 'cmake', required: false)
+  # On the linux CI, however, cmake cant find netcdf. So we still use pkg-config as a fallback.
+  if not netcdf_dep.found()
+    netcdf_dep = dependency('netcdf',  language : 'cpp', method: 'pkg-config')
+  endif
+  _deps += netcdf_dep
 endif
 
-_deps = [
+_deps += [
   pdflib_dep,
   dependency('xtensor'),
   dependency('xtensor-blas'),
   dependency('fmt'),
   dependency('tomlplusplus'),
-  netcdf_dep
 ]
 
 symbol_visibility = 'default'

--- a/meson.build
+++ b/meson.build
@@ -1,14 +1,29 @@
 project('flowy', 'cpp',
   version : '0.1',
-  default_options : ['warning_level=3', 'cpp_std=c++20', 'optimization=3'])
+  default_options : ['warning_level=3',
+                     'cpp_std=c++20',
+                     # 'buildtype=debugoptimize', # debug=true, optimize=2
+                     'debug=true',
+                     'optimization=3'])
 
 cpp_args = []
 
-cpp = meson.get_compiler('cpp')
+cppc = meson.get_compiler('cpp')
 
 # clang and gcc specific flags
-if cpp.get_id() == 'gcc' or cpp.get_id() == 'clang'
-  cpp_args += ['-Wno-unused-local-typedefs', '-Wno-array-bounds', '-ffast-math', '-fno-finite-math-only']
+if cppc.get_id() == 'gcc' or cppc.get_id() == 'clang'
+  cpp_args += cppc.get_supported_arguments([
+    '-Wno-unused-local-typedefs',
+    '-Wno-array-bounds',
+    '-ffast-math',
+    '-fno-finite-math-only',
+    # These are based on recommendations from
+    # https://youtu.be/_enXuIxuNV4?si=LvtMqPwJ6jYbDY66
+    '-fno-semantic-interposition',
+    '-fno-plt',
+    '-fvisibility=hidden',
+    '-Bsymbolic',
+  ])
 endif
 
 if cpp_args.length() > 0

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('build_shared_lib', type : 'boolean', value : false, description : 'Enable building of the shared library')
 option('build_tests', type : 'boolean', value : true, description : 'Enable building of the tests')
 option('build_exe', type : 'boolean', value : true, description : 'Enable building of the executable')
+option('with_netcdf', type : 'boolean', value : true, description : 'Include NetCDF support')

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -5,7 +5,6 @@
 #include "flowy/include/definitions.hpp"
 #include "flowy/include/lobe.hpp"
 #include "flowy/include/math.hpp"
-#include "flowy/include/netcdf_file.hpp"
 #include "flowy/include/topography.hpp"
 #include "flowy/include/topography_file.hpp"
 #include "pdf_cpplib/include/probability_dist.hpp"
@@ -23,6 +22,11 @@
 #include <random>
 #include <stdexcept>
 #include <vector>
+
+// This is more for clarity since the ifdef is in the netcdf_file as well
+#ifdef WITH_NETCDF
+#include "flowy/include/netcdf_file.hpp"
+#endif
 
 namespace Flowy
 {
@@ -474,6 +478,7 @@ Simulation::get_file_handle( const Topography & topography, OutputQuantitiy outp
 
     if( input.output_settings.use_netcdf )
     {
+#ifdef WITH_NETCDF
         auto netcdf_file        = NetCDFFile( topography, output_quantity );
         netcdf_file.compression = input.output_settings.compression;
         netcdf_file.data_type   = input.output_settings.data_type;
@@ -483,6 +488,9 @@ Simulation::get_file_handle( const Topography & topography, OutputQuantitiy outp
             netcdf_file.shuffle           = input.output_settings.shuffle;
         }
         res = std::make_unique<NetCDFFile>( netcdf_file );
+#else
+        throw std::runtime_error( "NetCDF requested but Flowy wasn't built with NetCDF support!\n" );
+#endif
     }
     else
     {


### PR DESCRIPTION
There's a little bit of scope creep here. Two things basically:
- Better `meson` defaults, resulting in a `.so` file reduction of around 15%
- Made `netcdf` optional and made sure compiling without it doesn't cause any errors
  - Also adding a CI configuration for the same